### PR TITLE
feat: Allow for setting the quality in startRecording

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-vision-camera",
-  "version": "2.15.3-unbogify",
+  "version": "2.15.4-unbogify",
   "description": "The Camera library that sees the vision.",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",

--- a/src/VideoFile.ts
+++ b/src/VideoFile.ts
@@ -40,6 +40,13 @@ export interface RecordVideoOptions {
    * @platform iOS
    */
   videoCodec?: CameraVideoCodec;
+  /**
+   * Sets quality Video Recording in terms of bitrate.
+   * quality 100 is the default quality with about 0.2 bits per pixel.
+   * Setting it to 20 will thus reduce the file size by 1/5.
+   * @default 100
+   */
+  quality?: number;
 }
 
 /**


### PR DESCRIPTION
Allow for setting the quality in startRecording

quality 100 resembles the default setting with around 0.2 bits per pixel. Setting quality to 10 will set the bitRate to one tenth of the default setting and thus will generate a roughtly 10 times smaller file.

